### PR TITLE
Don't disable existing loggers

### DIFF
--- a/python/ocrlayout_pkg/ocrlayout/bboxlog.py
+++ b/python/ocrlayout_pkg/ocrlayout/bboxlog.py
@@ -5,7 +5,7 @@ from os import path
 def get_logger():
     # Load Logging default configuration 
     log_file_path = path.join(path.dirname(path.abspath(__file__)), 'config/logging.conf')
-    logging.config.fileConfig(log_file_path)
+    logging.config.fileConfig(log_file_path, disable_existing_loggers=False)
     bboxlogger = logging.getLogger('bboxhelper')  # get a logger
     bboxlogger.setLevel(logging.INFO)
     return bboxlogger


### PR DESCRIPTION
When using `fileConfig`, the [default is `disable_existing_loggers=True`](https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig), which means that all loggers loaded until the call are disabled and won't be enabled again if not explicitly done. This is most certainly not the desired behavior for this function.

Edit: it's also uncommon to even configure logging in a public library. It's usually up to the users to do so. I just wanted to fix this, though, without major code changes. Hence just the one-liner.